### PR TITLE
Remove the downloaded zip in the postinstall

### DIFF
--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,7 +1,7 @@
 [Version]
 Upstream = 1.3.16
 Package  = 1.3.16.0
-Display  = 1.3.16-alpha1-uroesch
+Display  = 1.3.16-alpha2-uroesch
 
 [Archive]
 URL1         = https://github.com/cmderdev/cmder/releases/download/v1.3.16/cmder.zip

--- a/Other/Update/Postinstall.ps1
+++ b/Other/Update/Postinstall.ps1
@@ -1,0 +1,6 @@
+# Run the post-install script
+# basically only cleanup the downloaded zip
+
+Get-ChildItem $DownloadDir -Filter '*.zip' | Foreach-Object {
+  Remove-Item $_.FullName
+}


### PR DESCRIPTION
Summary:
  * Remove the `cmder.zip` files after unpacking
    to ensure the latest version is downloaded.